### PR TITLE
Allow configuration options to be stored in a dot file

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ No pip currently.
 - python2.7
 - py markdown (pip install markdown)
 - py pygments (pip install pygments)
+- py yaml (pip install yaml)
 - this repo
 
 Further a 256 color terminal (for now best with dark background) and font support for a few special separator characters (which you could change in mdv.py).

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ No pip currently.
  
 - python2.7
 - py markdown (pip install markdown)
+- py pygments (pip install pygments)
 - this repo
 
 Further a 256 color terminal (for now best with dark background) and font support for a few special separator characters (which you could change in mdv.py).

--- a/mdv.py
+++ b/mdv.py
@@ -987,6 +987,22 @@ def monitor_dir(args):
         sleep()
 
 
+def load_yaml_config():
+    import yaml
+    cfg = yaml.load('{}')
+    config_file = os.path.expanduser("~/.mdv")
+    if os.path.exists(config_file):
+        with open (config_file, "r") as mdvconfig:
+            try:
+                cfg = yaml.load(mdvconfig)
+            except IOError:
+                pass
+    return cfg
+
+def merge(a, b):
+    c = a.copy()
+    c.update(b)
+    return c
 
 def run_args(args):
     """ call the lib entry function with CLI args """
@@ -1003,11 +1019,10 @@ def run_args(args):
 
 if __name__ == '__main__':
     args = docopt(__doc__, version='mdv v0.1')
+    args = merge(args, load_yaml_config())
     if args.get('-m'):
         monitor(args)
     if args.get('-M'):
         monitor_dir(args)
     else:
         print run_args(args)
-
-


### PR DESCRIPTION
Love the tool but wanted to be able to specify those nice colours you had in the README.md all the time. Hope I didn't overlook a simpler way of doing this!