### PR TITLE
Correct yaml to pyyaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ No pip currently.
 ### Requirements
  
 - python2.7
-- py markdown (pip install markdown)
-- py pygments (pip install pygments)
-- py yaml (pip install yaml)
+- py markdown (`pip install markdown`)
+- py pygments (`pip install pygments`)
+- py yaml (`pip install pyyaml`)
 - this repo
 
 Further a 256 color terminal (for now best with dark background) and font support for a few special separator characters (which you could change in mdv.py).


### PR DESCRIPTION
Just a minor doc change, to install yaml it's `pip install pyyaml`.