### PR TITLE
Add docopt as required dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ never work in a language w/o bytestrings and the most important type based on
 - py markdown (pip install markdown)
 - py pygments (pip install pygments)
 - py yaml (pip install pyyaml)
+- py docopt (pip install docopt)
 
 Further a 256 color terminal (for now best with dark background) and font support for a few special separator characters (which you could change via config).
 


### PR DESCRIPTION
Install just failed because it was missing (ubuntu.16.04-arm)