### PR TITLE
fix github language statistic

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+mdv/misc/results_perftests/*.html linguist-vendored


### PR DESCRIPTION
ignore html on `mdv/misc/results_perftests`

result of github linguist before commit

```
59.02%  HTML
40.46%  Python
0.45%   Shell
0.06%   JavaScript

Python:
example_config/.mdv.py
mdv/__init__.py
mdv/markdownviewer.py
mdv/misc/perfest.py
mdv/tabulate.py
mdv/tests/files/manual/run_all.py
mdv/tests/test_files.py
mdv/tests/test_inline.py
setup.py

HTML:
mdv/misc/results_perftests/out_commonmark.html
mdv/misc/results_perftests/out_markdown.html
mdv/misc/results_perftests/out_mistletoe.html
mdv/misc/results_perftests/out_mistletoe_ansi.html
mdv/misc/results_perftests/out_paka.html
mdv/misc/results_perftests/out_paka_breaks.html
mdv/misc/results_perftests/out_paka_xml.html

JavaScript:
mdv/tests/files/manual/js.js

Shell:
mdv/tests/files/run
```

after

```
98.74%  Python
1.11%   Shell
0.16%   JavaScript

Python:
example_config/.mdv.py
mdv/__init__.py
mdv/markdownviewer.py
mdv/misc/perfest.py
mdv/tabulate.py
mdv/tests/files/manual/run_all.py
mdv/tests/test_files.py
mdv/tests/test_inline.py
setup.py

JavaScript:
mdv/tests/files/manual/js.js

Shell:
mdv/tests/files/run
```