### PR TITLE
add python3 compatibility for nonexistent admon

### DIFF
--- a/mdv/markdownviewer.py
+++ b/mdv/markdownviewer.py
@@ -987,7 +987,7 @@ class AnsiPrinter(Treeprocessor):
                     # not found - markup using hte first one's color:
                     if not _ad:
                         k = t[4:].split(' ', 1)[0]
-                        admons[k] = admons.values()[0]
+                        admons[k] = list(admons.values())[0]
 
                     pref = body_pref = '┃ '
                     pref += k.capitalize()


### PR DESCRIPTION
In python3, dict_value is not subscriptable. I've Converted 'dict_values' into a 'list' in order to avoid crashing mdv.