### PR TITLE
set the encoding of open explicitly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from setuptools import setup, find_packages
 
 version = "1.7.4"
 
-with open(os.path.join(os.path.dirname(__file__), "README.md")) as fd:
+with open(os.path.join(os.path.dirname(__file__), "README.md"), encoding='utf-8') as fd:
     md = fd.read()
 
 # images hack for pypi:


### PR DESCRIPTION
According to https://stackoverflow.com/questions/42070668/python-3-default-encoding-cp1252, https://stackoverflow.com/questions/49991870/python-default-string-encoding and so on, it's strongly recommended to use open(filename, encoding='utf-8') to read a file.