### PR TITLE
Fix deprecation warning for setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-description-file = README.md
+description_file = README.md
 [report]
 exclude_lines =
     pragma: no cover


### PR DESCRIPTION
W/o the patch, installation throws the warning:

```
python setup.py -V
/usr/lib/python3.9/site-packages/setuptools/dist.py:697: UserWarning: Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscore name 'description_file' instead
  warnings.warn(
```

**upd**: thank you for keeping PRs merged! Can you consider the releasing new versions as well, please?