### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # coding: utf-8
 
 """_


### PR DESCRIPTION
Fixed install when Python 3 is the primary version for the system and there are no modules currently installed for the other older version.