### PR TITLE
Updated setup file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # coding: utf-8
 
 """_
@@ -14,7 +14,7 @@
 import os
 from setuptools import setup, find_packages
 
-version = '1.7.4'
+version = '1.7.5'
 
 with open(os.path.join(os.path.dirname(__file__), 'README.md')) as fd:
     md = fd.read()
@@ -48,6 +48,9 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
     entry_points={'console_scripts': ['mdv = mdv:run']},
 )


### PR DESCRIPTION
The setup file shall be updated with a next minor version.

The current issue is that `pip install mdv` refers to a version of the 1.7.4 package that does not include fixes for #97 , #102 and #105 . You should thus increase the version and repush it to pypi.org.