### PR TITLE
Include color schemes in the package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,5 @@ include README.md
 include LICENSE
 include licenses/*
 include mdv/ansi_tables.json
+include mdv/5color/*.json
+include mdv/b16/*.json


### PR DESCRIPTION
Without it, the program doesn't work with the following issue:

```
$ mdv README.md
Traceback (most recent call last):
  File "/usr/bin/mdv", line 33, in <module>
    sys.exit(load_entry_point('mdv==1.7.5', 'console_scripts', 'mdv')())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/mdv/markdownviewer.py", line 1706, in run
    print(main(**kw) if PY3 else str(main(**kw)))
          ^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/mdv/markdownviewer.py", line 1312, in main
    theme = random_theme(theme_dirs)
            ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/mdv/markdownviewer.py", line 1249, in random_theme
    [r.extend([k for k in os.listdir(d) if k.endswith('.json')]) for d in dirs]
  File "/usr/lib/python3.11/site-packages/mdv/markdownviewer.py", line 1249, in <listcomp>
    [r.extend([k for k in os.listdir(d) if k.endswith('.json')]) for d in dirs]
                          ^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/usr/lib/python3.11/site-packages/mdv/b16'
```